### PR TITLE
Resolvendo problemas de drop em lista e em lista vazia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # youtube-ui-clone-pipefy
 Código produzido durante o vídeo "Recriando Pipefy do zero (com drag n' drop)"
 
-Acompanhei esse projeto interessando do Diego Fernandes CTO da RocketSeat e resolvi dar minha contribuição.
+Acompanhei esse projeto interessante do Diego Fernandes CTO da RocketSeat e resolvi dar minha contribuição.
 
 
 1 - Mover Cards para uma lista vazia.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# youtube-ui-clone-pipefy
+Código produzido durante o vídeo "Recriando Pipefy do zero (com drag n' drop)"
+
+Acompanhei esse projeto interessando do Diego Fernandes CTO da RocketSeat e resolvi dar minha contribuição.
+
+
+1 - Mover Cards para uma lista vazia.

--- a/src/components/Board/index.js
+++ b/src/components/Board/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import produce from 'immer';
 
 import { loadLists } from '../../services/api';
@@ -11,13 +11,32 @@ import { Container } from './styles';
 
 const data = loadLists();
 
+
+
+
 export default function Board() {
   const [lists, setLists] = useState(data);
+  const [isMovingCard, setIsMovingCard] = useState(false);
+
+
+  const handleDrop = useCallback(
+    (index, item) => {
+      if(!isMovingCard){
+        setLists(produce(lists, draft => {
+          const dragged = draft[item.listIndex].cards[item.index];
+          draft[item.listIndex].cards.splice(item.index, 1);
+          draft[index].cards.push(dragged);
+        }))
+      }else{
+        setIsMovingCard(false);
+      }
+    },
+  )
 
   function move(fromList, toList, from, to) {
     setLists(produce(lists, draft => {
       const dragged = draft[fromList].cards[from];
-
+      setIsMovingCard(true);
       draft[fromList].cards.splice(from, 1);
       draft[toList].cards.splice(to, 0, dragged);
     }))
@@ -26,7 +45,7 @@ export default function Board() {
   return (
     <BoardContext.Provider value={{ lists, move }}>
       <Container>
-        {lists.map((list, index) => <List key={list.title} index={index} data={list} />)}
+        {lists.map((list, index) => <List accepts={['CARD']} onDrop={item => handleDrop(index, item)} key={list.title} index={index} data={list} />)}
       </Container>
     </BoardContext.Provider>
   );

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -8,7 +8,7 @@ import { Container, Label } from './styles';
 export default function Card({ data, index, listIndex }) {
   const ref = useRef();
   const { move } = useContext(BoardContext);
-
+  let memTime = 0;
   const [{ isDragging }, dragRef] = useDrag({
     item: { type: 'CARD', index, listIndex },
     collect: monitor => ({
@@ -19,6 +19,9 @@ export default function Card({ data, index, listIndex }) {
   const [, dropRef] = useDrop({
     accept: 'CARD',
     hover(item, monitor) {
+      var date = new Date();
+      var now = date.getTime();
+      if(memTime == 0) memTime = now;
       const draggedListIndex = item.listIndex;
       const targetListIndex = listIndex;
 
@@ -38,15 +41,15 @@ export default function Card({ data, index, listIndex }) {
       if (draggedIndex < targetIndex && draggedTop < targetCenter) {
         return;
       }
-
       if (draggedIndex > targetIndex && draggedTop > targetCenter) {
         return;
       }
-
-      move(draggedListIndex, targetListIndex, draggedIndex, targetIndex);
-
-      item.index = targetIndex;
-      item.listIndex = targetListIndex;
+      if((now - memTime) >= 300 || draggedListIndex == targetListIndex){
+        move(draggedListIndex, targetListIndex, draggedIndex, targetIndex,'card');
+        item.index = targetIndex;
+        item.listIndex = targetListIndex;
+        memTime = 0;
+      }
     }
   })
 

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -4,10 +4,14 @@ import { MdAdd } from 'react-icons/md';
 
 import Card from '../Card';
 
+import { DropTarget } from 'react-dnd';
+
 import { Container } from './styles';
 
-export default function List({ data, index: listIndex }) {
-  return (
+function List({ data, index: listIndex, connectDropTarget }) {
+  
+  return connectDropTarget(
+    <div style={{flexGrow:0,flexShrink:0,flexBasis:320}}>
     <Container done={data.done}>
       <header>
         <h2>{data.title}</h2>
@@ -29,5 +33,19 @@ export default function List({ data, index: listIndex }) {
         )) }
       </ul>
     </Container>
+    </div>
   );
 }
+
+export default DropTarget (
+  props => props.accepts,
+  {
+    drop(props, monitor) {
+      props.onDrop(monitor.getItem())
+    },
+  },
+  (connect, monitor) => ({
+    connectDropTarget: connect.dropTarget(),
+    isOver: monitor.isOver(),
+  }),
+)(List);


### PR DESCRIPTION
Fala devs, pra quem tiver interesse em como resolver os pequenos probleminhas de drop em lista criei esse pull.
primeiro resolvi o problema de lista e de lista vazia, mas me deparei com um outro problema quando tentava mover um card por exemplo da primeira para a terceira lista, se eu passasse sobre um card da segunda lista ele automaticamente se movia para lá. Para resolver isso criei um timer, que é ativado apenas ao mover o card de uma lista pra outra. Dessa forma se mover o card dentro da mesma lista continua normal, se eu soltar em outra lista também, mas se eu quiser moer pra outra lista em cima de um card basta deixar o card parado por um tempo, coloquei 300ms, mas cada um pode configurar como achar melhor.
Espero que goste, e obrigado Rocketseat. 
